### PR TITLE
Use the correct version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Basic usage with all options enabled:
 ```yaml
 
       - name: markdownlint-cli
-        uses: nosborn/github-action-markdown-cli@v1.1
+        uses: nosborn/github-action-markdown-cli@v1.1.1
         with:
           config_file: ".markdownlint.yaml"
           files: .

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Basic usage with all options enabled:
       - name: markdownlint-cli
         uses: nosborn/github-action-markdown-cli@v1.1.1
         with:
-          config_file: ".markdownlint.yaml"
           files: .
+          config_file: ".markdownlint.yaml"
           ignore_files: "examples/ignore/*"
           rules: "examples/rules/custom.js"
 
@@ -20,10 +20,10 @@ Basic usage with all options enabled:
 
 ## Inputs
 
-* `config_file` - configuration file (JSON or YAML)
-* `files` - what to process, this is required - files, directories, globs
-* `ignore_files` - files to ignore/exclude - file, directory, glob
-* `rules` - custom rule files - file, directory, glob, package
+* `files` - what to process (files, directories, globs)
+* `config_file` (optional) - configuration file (JSON or YAML)
+* `ignore_files` (optional) - files to ignore/exclude (file, directory, glob)
+* `rules` (optional) - custom rule files (file, directory, glob, package)
 
 ## License
 


### PR DESCRIPTION
# Changes proposed
- Fix the version in the README. When using `nosborn/github-action-markdown-cli@v1.1`, the error on GitHub actions is:

    ```
    Download action repository 'nosborn/github-action-markdown-cli@v1.1'
    ##[warning]Failed to download action 'https://api.github.com/repos/nosborn/github-action-markdown-cli/tarball/v1.1'. Error Response status code does not indicate success: 404 (Not Found).
    ##[warning]Back off 25.634 seconds before retry.
    ##[warning]Failed to download action 'https://api.github.com/repos/nosborn/github-action-markdown-cli/tarball/v1.1'. Error Response status code does not indicate success: 404 (Not Found).
    ##[warning]Back off 19.142 seconds before retry.
    ##[error]Response status code does not indicate success: 404 (Not Found).
    ```

    The versions shown in https://github.com/marketplace/actions/markdownlint-cli are currently `v1.1.1`, `v.1.1.0` and `v1`.

- Put the mandatory parameter (`files`) first and add `(optional)` to the others