### PR TITLE
Bump markdownlint-cli dependency version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-alpine
 
-RUN npm install --global --production --update-notifier=false markdownlint-cli@0.30.0
+RUN npm install --global --production --update-notifier=false markdownlint-cli@0.31.1
 
 COPY entrypoint.sh /entrypoint.sh
 COPY markdownlint-problem-matcher.json /markdownlint-problem-matcher.json


### PR DESCRIPTION
to get latest features and fix possible problems related to the `0.30.0` version
which also bumps `markdownlint` to their latest available version
https://github.com/igorshubovych/markdownlint-cli/blob/master/package.json#L46