### PR TITLE
Bump markdownlint-cli to 0.33.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-alpine
 
-RUN npm install --global --production --update-notifier=false markdownlint-cli@0.32.2
+RUN npm install --global --production --update-notifier=false markdownlint-cli@0.33.0
 
 COPY entrypoint.sh /entrypoint.sh
 COPY markdownlint-problem-matcher.json /markdownlint-problem-matcher.json


### PR DESCRIPTION
Update to last version of markdownlint-cli. 