### PR TITLE
Bump markdownlint-cli to 0.43.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-alpine
 
-RUN npm install --global --production --update-notifier=false markdownlint-cli@0.33.0
+RUN npm install --global --production --update-notifier=false markdownlint-cli@0.43.0
 
 COPY entrypoint.sh /entrypoint.sh
 COPY markdownlint-problem-matcher.json /markdownlint-problem-matcher.json


### PR DESCRIPTION
I'm hoping this will fix the following deprecation notice:

> [DEP0040] DeprecationWarning: The `punycode` module is deprecated.